### PR TITLE
Ignore the generated python files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ dist/*
 .libs/*
 Makefile
 Makefile.in
+python/cal/ws_consts.py
+python/cal/ws_types.py


### PR DESCRIPTION
Adding the generated python files the to .gitignore file so that it they do not show up as untracked in the git status.