### PR TITLE
Update 1.10 template

### DIFF
--- a/templates/ws_types.py.1_10
+++ b/templates/ws_types.py.1_10
@@ -103,6 +103,15 @@ class WSstring_string(Structure):
 class WSrange_string(Structure):
     pass    
     
+class WSenum_val(Structure):
+    """
+    Definition of a value for an enumerated type.
+    "name" is the the name one would use on the command line for the value.
+    "description" is the description of the value, used in combo boxes option menus.
+    "value" is the value.
+    """
+    pass
+
 WSns_time._fields_ = [("secs", c_int), # Should work on most systems
                       ("nsecs", c_int)]
                       
@@ -270,3 +279,7 @@ WSvalue_string._fields_ = [("value", c_int32),
 WSrange_string._fields_= [("value_min", c_int32),
                           ("value_max", c_int32),
                           ("str", c_char_p)]
+
+WSenum_val._fields_ = [("name", c_char_p),
+                       ("description", c_char_p),
+                       ("value", c_int32)]

--- a/templates/ws_types.py.1_10
+++ b/templates/ws_types.py.1_10
@@ -27,6 +27,8 @@ WS_CREATE_DISSECTOR_HANDLE_ARGS = [c_void_p, c_int]
 WS_CREATE_DISSECTOR_HANDLE_RETURN = c_void_p
 WS_DISSECTOR_ADD_UINT_ARGS = [c_char_p, c_uint32, c_void_p]
 WS_DISSECTOR_ADD_STRING_ARGS = [c_char_p, c_char_p, c_void_p]
+WS_EXPERT_ADD_INFO_FORMAT_ARGS = [c_void_p, c_void_p, c_int, c_int, c_char_p]
+WS_EXPERT_ADD_INFO_FORMAT_RETURN = c_void_p;
 
 class WStvb_backing(Structure):
     pass


### PR DESCRIPTION
Updating the ws_types.py template for wireshark 1.10 with expert info arguments, returns, and the enum type.