### PR TITLE
Allow the pyreshark plugin to be placed in the user directory

### DIFF
--- a/python/pyreshark.py
+++ b/python/pyreshark.py
@@ -25,25 +25,25 @@ Don't import this, as it relies on sys being already imported in the C code
 import os.path
 from glob import glob
 import traceback
+import pyreshark_locator
 
 for directory in sys.path:
     if os.path.realpath(directory) == os.path.realpath("."):
         sys.path.remove(directory)
         break
 
-PYRESHARK_DIR = sys.path[-1]
+PYRESHARK_DIR = pyreshark_locator.module_path()
 PROTOCOLS_DIR = os.path.join(PYRESHARK_DIR, "protocols")
-
 
 # The following is to handle the situation where the user doesn't have enough privileges to open the logs.
 try:
-    sys.stdout = open(os.path.join("%s" % (sys.path[-1],),"out.log") ,"wb")
-    sys.stderr = open(os.path.join("%s" % (sys.path[-1],),"err.log") ,"wb")
+    sys.stdout = open(os.path.join("%s" % (PYRESHARK_DIR,),"out.log") ,"wb")
+    sys.stderr = open(os.path.join("%s" % (PYRESHARK_DIR,),"err.log") ,"wb")
 except:
     pass
 
 sys.path.append(PROTOCOLS_DIR)
-    
+
 import cal
 
 class PyreShark(object):
@@ -57,7 +57,7 @@ class PyreShark(object):
         self._protocols = []
         self._cal = cal.CAL()
         protocol_files = glob(os.path.join("%s" % (PROTOCOLS_DIR,), "*.py"))
-        
+
         for p_file in protocol_files:
             try:
                 proto_module = __import__(p_file.replace("%s%s" % (PROTOCOLS_DIR, os.path.sep), "").replace(".py", ""))
@@ -67,9 +67,9 @@ class PyreShark(object):
                 message = "Pyreshark error:\n" + "\n".join(exc[-3:])
                 self._cal.error_message(message)
                 traceback.print_exc(file=sys.stderr)
-        
+
         self._cal.register_protocols(self._protocols)
-        
+
     def handoff(self):
         '''
         @summary: Calls the handoff function in each one of the protocols.

--- a/python/pyreshark_locator.py
+++ b/python/pyreshark_locator.py
@@ -1,0 +1,5 @@
+import os.path
+
+
+def module_path():
+    return os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Rearrange the import code of the python modules so that the pyreshark.py and any user-provided dissectors can be loaded from the user wireshark directory (~/.wireshark/python on Linux) or from the global wireshark directory (/usr/share/wireshark/python on my Ubuntu machine). This resulted in the addition of a small python file whose sole purpose is to be imported by the pyreshark.py file so that it can figure out where it is located on the system (which of the two directories was it in to know where the protocol directory should be).

This rearrangement also cleans up a small memory leak from the use of get_datafile_path().
